### PR TITLE
Add check for links

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,6 +23,8 @@ module.exports = (robot) => {
     })
 
     // Add links as attachments
-    return attachments(context).add(await Promise.all(links))
+    if (links.length > 0) {
+      return attachments(context).add(await Promise.all(links))
+    }
   }
 }


### PR DESCRIPTION
👋 I noticed that `unfurl` was triggering even when there were no links in the issue comment. When there are no links, `unfurl` should do nothing.