### PR TITLE
Replaced attachments when editing comments

### DIFF
--- a/lib/commitunfurl.js
+++ b/lib/commitunfurl.js
@@ -14,29 +14,33 @@ module.exports = async function commitunfurl (context, html) {
 
   const links = getLinks(html)
 
-  if (links.length === Oldlinks.length) {
+  const newLinks = links.filter(function (item, position) {
+    return links.indexOf(item) === position
+  })
+
+  if (newLinks.length === Oldlinks.length) {
     context.log('Matched links so cannot unfurl anythings')
   } else {
-    if (links.length === 1) {
-      context.log(links, 'Unfurling links')
+    if (newLinks.length === 1) {
+      context.log(newLinks, 'Unfurling links')
 
       // Unfurl them into attachments
-      const unfurls = await Promise.all(links.map(link => unfurlToAttachment(link)))
+      const unfurls = await Promise.all(newLinks.map(link => unfurlToAttachment(link)))
 
       context.log.trace(unfurls, 'Unfurled links')
 
       // Attaches unfurled links to the comment
       return attachments(context).add(unfurls)
-    } else if (links.length > 1) { // this block runs for more than 1 link
+    } else if (newLinks.length > 1) { // this block runs for more than 1 link
       // this will remove old links
       for (let i = 0; i < Oldlinks.length; i++) {
-        links.shift()
+        newLinks.shift()
       }
 
-      context.log(links, 'Unfurling links')
+      context.log(newLinks, 'Unfurling links')
 
       // Unfurl them into attachments
-      const unfurls = await Promise.all(links.map(link => unfurlToAttachment(link)))
+      const unfurls = await Promise.all(newLinks.map(link => unfurlToAttachment(link)))
 
       context.log.trace(unfurls, 'Unfurled links')
 

--- a/lib/commitunfurl.js
+++ b/lib/commitunfurl.js
@@ -2,7 +2,7 @@ const unfurlToAttachment = require('./unfurl-to-attachment')
 const attachments = require('probot-attachments')
 const getLinks = require('./get-links')
 const {JSDOM} = require('jsdom')
-module.exports = async function commitunfurl (context, html, configMax) {
+module.exports = async function commitunfurl (context, html) {
   // Find all the old links
   const Oldlinks = []
   // Parse the HTML

--- a/lib/commitunfurl.js
+++ b/lib/commitunfurl.js
@@ -1,0 +1,35 @@
+const unfurlToAttachment = require('./unfurl-to-attachment')
+const attachments = require('probot-attachments')
+const getLinks = require('./get-links')
+module.exports = async function commitunfurl (context, html) {
+  // Find all the links
+  const links = getLinks(html)
+  // If only one link is this this block runs
+
+  if (links.length === 1) {
+    context.log(links, 'Unfurling links')
+
+    // Unfurl them into attachments
+    const unfurls = await Promise.all(links.map(link => unfurlToAttachment(link)))
+
+    context.log.trace(unfurls, 'Unfurled links')
+
+    // Attaches unfurled links to the comment
+    return attachments(context).add(unfurls)
+  } else if (links.length > 1) { // this block runs for more than 1 link
+    // this will remove old links
+    for (let i = 0; i <= links.length - 1; i++) {
+      links.shift()
+    }
+
+    context.log(links, 'Unfurling links')
+
+    // Unfurl them into attachments
+    const unfurls = await Promise.all(links.map(link => unfurlToAttachment(link)))
+
+    context.log.trace(unfurls, 'Unfurled links')
+
+    // Attaches unfurled links to the comment
+    return attachments(context).add(unfurls)
+  }
+}

--- a/lib/commitunfurl.js
+++ b/lib/commitunfurl.js
@@ -1,35 +1,47 @@
 const unfurlToAttachment = require('./unfurl-to-attachment')
 const attachments = require('probot-attachments')
 const getLinks = require('./get-links')
-module.exports = async function commitunfurl (context, html) {
-  // Find all the links
+const {JSDOM} = require('jsdom')
+module.exports = async function commitunfurl (context, html, configMax) {
+  // Find all the old links
+  const Oldlinks = []
+  // Parse the HTML
+  const frag = JSDOM.fragment(context.payload.changes.body.from)
+  // Find all the links and save then
+  frag.querySelectorAll('a').forEach(a => {
+    Oldlinks.push((a.href).toLowerCase())
+  })
+
   const links = getLinks(html)
-  // If only one link is this this block runs
 
-  if (links.length === 1) {
-    context.log(links, 'Unfurling links')
+  if (links.length === Oldlinks.length) {
+    context.log('Matched links so cannot unfurl anythings')
+  } else {
+    if (links.length === 1) {
+      context.log(links, 'Unfurling links')
 
-    // Unfurl them into attachments
-    const unfurls = await Promise.all(links.map(link => unfurlToAttachment(link)))
+      // Unfurl them into attachments
+      const unfurls = await Promise.all(links.map(link => unfurlToAttachment(link)))
 
-    context.log.trace(unfurls, 'Unfurled links')
+      context.log.trace(unfurls, 'Unfurled links')
 
-    // Attaches unfurled links to the comment
-    return attachments(context).add(unfurls)
-  } else if (links.length > 1) { // this block runs for more than 1 link
-    // this will remove old links
-    for (let i = 0; i <= links.length - 1; i++) {
-      links.shift()
+      // Attaches unfurled links to the comment
+      return attachments(context).add(unfurls)
+    } else if (links.length > 1) { // this block runs for more than 1 link
+      // this will remove old links
+      for (let i = 0; i < Oldlinks.length; i++) {
+        links.shift()
+      }
+
+      context.log(links, 'Unfurling links')
+
+      // Unfurl them into attachments
+      const unfurls = await Promise.all(links.map(link => unfurlToAttachment(link)))
+
+      context.log.trace(unfurls, 'Unfurled links')
+
+      // Attaches unfurled links to the comment
+      return attachments(context).add(unfurls)
     }
-
-    context.log(links, 'Unfurling links')
-
-    // Unfurl them into attachments
-    const unfurls = await Promise.all(links.map(link => unfurlToAttachment(link)))
-
-    context.log.trace(unfurls, 'Unfurled links')
-
-    // Attaches unfurled links to the comment
-    return attachments(context).add(unfurls)
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,8 +7,19 @@ module.exports = (robot) => {
       id: context.payload.comment.id,
       headers: { accept: 'application/vnd.github.html+json' }
     }))
-
     return unfurl(context, comment.data.body_html)
+  })
+  // this will run when comment is edited
+  robot.on(['issue_comment.edited'], async context => {
+    const comment = await context.github.issues.getComment(context.repo({
+      id: context.payload.comment.id,
+      headers: { accept: 'application/vnd.github.html+json' }
+    }))
+    if (context.payload.sender.login !== 'unfurl-links[bot]') { // change this to name of your bot
+      return unfurl(context, comment.data.body_html)
+    } else {
+      context.log('sorry bot cannot edit commit messages') // preventing looping of edit of comments
+    }
   })
 
   robot.on(['issues.opened', 'pull_request.opened'], async context => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 const unfurl = require('./unfurl')
-
+const commitunfurl = require('./commitunfurl')
 module.exports = (robot) => {
   robot.on(['issue_comment.created'], async context => {
     // Get the rendered HTML of the comment from GitHub
@@ -16,7 +16,7 @@ module.exports = (robot) => {
       headers: { accept: 'application/vnd.github.html+json' }
     }))
     if (context.payload.sender.login !== 'unfurl-links[bot]') { // change this to name of your bot
-      return unfurl(context, comment.data.body_html)
+      return commitunfurl(context, comment.data.body_html)
     } else {
       context.log('sorry bot cannot edit commit messages') // preventing looping of edit of comments
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -15,7 +15,7 @@ module.exports = (robot) => {
       id: context.payload.comment.id,
       headers: { accept: 'application/vnd.github.html+json' }
     }))
-    if (context.payload.sender.login !== 'unfurl-links[bot]') { // change this to name of your bot
+    if (context.payload.sender.type !== 'Bot') { // change this to name of your bot
       return commitunfurl(context, comment.data.body_html)
     } else {
       context.log('sorry bot cannot edit commit messages') // preventing looping of edit of comments

--- a/lib/unfurl.js
+++ b/lib/unfurl.js
@@ -1,12 +1,26 @@
 const unfurlToAttachment = require('./unfurl-to-attachment')
 const attachments = require('probot-attachments')
 const getLinks = require('./get-links')
-
 module.exports = async function unfurl (context, html) {
   // Find all the links
   const links = getLinks(html)
+  // If only one link is this this block runs
+  if (links.length === 1) {
+    context.log(links, 'Unfurling links')
 
-  if (links.length > 0) {
+    // Unfurl them into attachments
+    const unfurls = await Promise.all(links.map(link => unfurlToAttachment(link)))
+
+    context.log.trace(unfurls, 'Unfurled links')
+
+    // Attaches unfurled links to the comment
+    return attachments(context).add(unfurls)
+  } else if (links.length > 1) { // this block runs for more than 1 link
+    // this will remove old links
+    for (let i = 0; i <= links.length - 1; i++) {
+      links.shift()
+    }
+
     context.log(links, 'Unfurling links')
 
     // Unfurl them into attachments

--- a/lib/unfurl.js
+++ b/lib/unfurl.js
@@ -6,11 +6,15 @@ module.exports = async function unfurl (context, html) {
   // Find all the links
   const links = getLinks(html)
 
-  if (links.length > 0) {
-    context.log(links, 'Unfurling links')
+  const newLinks = links.filter(function (item, position) {
+    return links.indexOf(item) === position
+  })
+
+  if (newLinks.length > 0) {
+    context.log(newLinks, 'Unfurling links')
 
     // Unfurl them into attachments
-    const unfurls = await Promise.all(links.map(link => unfurlToAttachment(link)))
+    const unfurls = await Promise.all(newLinks.map(link => unfurlToAttachment(link)))
 
     context.log.trace(unfurls, 'Unfurled links')
 

--- a/lib/unfurl.js
+++ b/lib/unfurl.js
@@ -1,26 +1,12 @@
 const unfurlToAttachment = require('./unfurl-to-attachment')
 const attachments = require('probot-attachments')
 const getLinks = require('./get-links')
+
 module.exports = async function unfurl (context, html) {
   // Find all the links
   const links = getLinks(html)
-  // If only one link is this this block runs
-  if (links.length === 1) {
-    context.log(links, 'Unfurling links')
 
-    // Unfurl them into attachments
-    const unfurls = await Promise.all(links.map(link => unfurlToAttachment(link)))
-
-    context.log.trace(unfurls, 'Unfurled links')
-
-    // Attaches unfurled links to the comment
-    return attachments(context).add(unfurls)
-  } else if (links.length > 1) { // this block runs for more than 1 link
-    // this will remove old links
-    for (let i = 0; i <= links.length - 1; i++) {
-      links.shift()
-    }
-
+  if (links.length > 0) {
     context.log(links, 'Unfurling links')
 
     // Unfurl them into attachments


### PR DESCRIPTION
This is reference to <a href="https://github.com/probot/unfurl/issues/2">#2</a>

<strong>Added functionality: </strong>

1.) Adding attachment on editing comment.

2.) Only adding attachments for new link and deleting for old links

3.) If no link is provided then does not unfurl old attachments

4.) Avoid unfurling of same URL.