### PR TITLE
Enhancement: Ignore links came from emails.

### DIFF
--- a/lib/get-links.js
+++ b/lib/get-links.js
@@ -6,13 +6,17 @@ module.exports = html => {
   // Parse the HTML
   const frag = JSDOM.fragment(html)
 
-  // Find all the links
-  frag.querySelectorAll('a').forEach(a => {
-    // Only unfurl raw links. GitHub also adds a trailing `/`
-    if (a.href === a.innerHTML || a.href === `${a.innerHTML}/`) {
-      links.push(a.href)
-    }
-  })
+  // Check if the content came from an email
+  const isEmail = !!frag.querySelectorAll('.email-fragment').length
 
+  if (!isEmail) {
+    // Find all the links
+    frag.querySelectorAll('a').forEach(a => {
+      // Only unfurl raw links. GitHub also adds a trailing `/`
+      if (a.href === a.innerHTML || a.href === `${a.innerHTML}/`) {
+        links.push(a.href)
+      }
+    })
+  }
   return links
 }

--- a/lib/get-links.js
+++ b/lib/get-links.js
@@ -7,7 +7,7 @@ module.exports = html => {
   const frag = JSDOM.fragment(html)
 
   // Check if the content came from an email
-  const isEmail = !!frag.querySelector('.email-fragment').length
+  const isEmail = !!frag.querySelectorAll('.email-fragment').length
 
   if (!isEmail) {
     // Find all the links

--- a/lib/get-links.js
+++ b/lib/get-links.js
@@ -7,7 +7,7 @@ module.exports = html => {
   const frag = JSDOM.fragment(html)
 
   // Check if the content came from an email
-  const isEmail = !!frag.querySelectorAll('.email-fragment').length
+  const isEmail = !!frag.querySelector('.email-fragment').length
 
   if (!isEmail) {
     // Find all the links

--- a/lib/unfurl-to-attachment.js
+++ b/lib/unfurl-to-attachment.js
@@ -1,14 +1,39 @@
 const unfurl = require('unfurl.js')
+const UrlParser = require('url')
 
 module.exports = async function unfurlToAttachment (url) {
   const data = await unfurl(url)
+  const parsedUrl = UrlParser.parse(url)
+  let baseUrl, authorIcon
 
-  const description = (data.ogp && data.ogp.ogDescription) || (data.other && data.other.description)
+  if (data.other && data.other.icon) {
+    const parseIconUrl = UrlParser.parse(data.other.icon)
+    if (!parseIconUrl.protocol && !parseIconUrl.host) {
+      baseUrl = parsedUrl.protocol + '//' + parsedUrl.host
+    } else if (!parseIconUrl.protocol && parseIconUrl.host) {
+      baseUrl = parsedUrl.protocol + '//'
+    }
+  }
+  if (baseUrl) {
+    authorIcon = baseUrl + (data.other && data.other.icon)
+  } else {
+    authorIcon = data.other && data.other.icon
+  }
+
+  const description =
+    (data.ogp && data.ogp.ogDescription) ||
+    (data.other && data.other.description)
   const authorName = data.ogp && data.ogp.ogSiteName
-  const authorIcon = data.other && data.other.icon
-  const title = (data.ogp && data.ogp.ogTitle) || (data.other && data.other.title && data.other.title.trim())
+  const title =
+    (data.ogp && data.ogp.ogTitle) ||
+    (data.other && data.other.title && data.other.title.trim())
   const titleLink = (data.ogp && data.ogp.ogUrl) || url
-  const thumbUrl = (data.ogp && data.ogp.ogImage && data.ogp.ogImage[0] && data.ogp.ogImage[0].url) || (data.other && data.other.shortcutIcon)
+  const thumbUrl =
+    (data.ogp &&
+      data.ogp.ogImage &&
+      data.ogp.ogImage[0] &&
+      data.ogp.ogImage[0].url) ||
+    (data.other && data.other.shortcutIcon)
 
   return {
     fallback: description,

--- a/lib/unfurl-to-attachment.js
+++ b/lib/unfurl-to-attachment.js
@@ -1,39 +1,14 @@
 const unfurl = require('unfurl.js')
-const UrlParser = require('url')
 
 module.exports = async function unfurlToAttachment (url) {
   const data = await unfurl(url)
-  const parsedUrl = UrlParser.parse(url)
-  let baseUrl, authorIcon
 
-  if (data.other && data.other.icon) {
-    const parseIconUrl = UrlParser.parse(data.other.icon)
-    if (!parseIconUrl.protocol && !parseIconUrl.host) {
-      baseUrl = parsedUrl.protocol + '//' + parsedUrl.host
-    } else if (!parseIconUrl.protocol && parseIconUrl.host) {
-      baseUrl = parsedUrl.protocol + '//'
-    }
-  }
-  if (baseUrl) {
-    authorIcon = baseUrl + (data.other && data.other.icon)
-  } else {
-    authorIcon = data.other && data.other.icon
-  }
-
-  const description =
-    (data.ogp && data.ogp.ogDescription) ||
-    (data.other && data.other.description)
+  const description = (data.ogp && data.ogp.ogDescription) || (data.other && data.other.description)
   const authorName = data.ogp && data.ogp.ogSiteName
-  const title =
-    (data.ogp && data.ogp.ogTitle) ||
-    (data.other && data.other.title && data.other.title.trim())
+  const authorIcon = data.other && data.other.icon
+  const title = (data.ogp && data.ogp.ogTitle) || (data.other && data.other.title && data.other.title.trim())
   const titleLink = (data.ogp && data.ogp.ogUrl) || url
-  const thumbUrl =
-    (data.ogp &&
-      data.ogp.ogImage &&
-      data.ogp.ogImage[0] &&
-      data.ogp.ogImage[0].url) ||
-    (data.other && data.other.shortcutIcon)
+  const thumbUrl = (data.ogp && data.ogp.ogImage && data.ogp.ogImage[0] && data.ogp.ogImage[0].url) || (data.other && data.other.shortcutIcon)
 
   return {
     fallback: description,

--- a/test/get-links.test.js
+++ b/test/get-links.test.js
@@ -17,4 +17,11 @@ describe('get-links', () => {
 
     expect(links).toEqual([])
   })
+
+  test('ignores links with email-fragment class at parent', () => {
+    const links = getLinks(`
+    <div class="email-fragment"><a href="https://etsy.com/">Lovingly hand crafted links</a></div>
+    `)
+    expect(links).toEqual([])
+  })
 })


### PR DESCRIPTION
As seen at #8, Unfurl will try to "unfurl" links to a reply that is sent via email. Since GitHub does not support markdown with email replies so the comment edited by **Unfurl** get appended by `html` tags instead of actual unfurled links.
To avoid that, we can avoid unfurling links that came from an email. This PR does the same. 