### PR TITLE
avoid dup unfurls

### DIFF
--- a/lib/get-links.js
+++ b/lib/get-links.js
@@ -18,5 +18,7 @@ module.exports = html => {
       }
     })
   }
-  return links
+
+  // Avoid duplicate identical links
+  return Array.from(new Set(links))
 }

--- a/lib/unfurl.js
+++ b/lib/unfurl.js
@@ -8,9 +8,9 @@ module.exports = async function unfurl (context, html) {
 
   if (links.length > 0) {
     context.log(links, 'Unfurling links')
-    
+
     // Avoid duplicate identical links
-    const linkSet = new Set(links)
+    const linkSet = Array.from(new Set(links))
 
     // Unfurl them into attachments
     const unfurls = await Promise.all(linkSet.map(link => unfurlToAttachment(link)))

--- a/lib/unfurl.js
+++ b/lib/unfurl.js
@@ -8,9 +8,12 @@ module.exports = async function unfurl (context, html) {
 
   if (links.length > 0) {
     context.log(links, 'Unfurling links')
+    
+    // Avoid duplicate identical links
+    const linkSet = new Set(links)
 
     // Unfurl them into attachments
-    const unfurls = await Promise.all(links.map(link => unfurlToAttachment(link)))
+    const unfurls = await Promise.all(linkSet.map(link => unfurlToAttachment(link)))
 
     context.log.trace(unfurls, 'Unfurled links')
 

--- a/lib/unfurl.js
+++ b/lib/unfurl.js
@@ -9,11 +9,8 @@ module.exports = async function unfurl (context, html) {
   if (links.length > 0) {
     context.log(links, 'Unfurling links')
 
-    // Avoid duplicate identical links
-    const linkSet = Array.from(new Set(links))
-
     // Unfurl them into attachments
-    const unfurls = await Promise.all(linkSet.map(link => unfurlToAttachment(link)))
+    const unfurls = await Promise.all(links.map(link => unfurlToAttachment(link)))
 
     context.log.trace(unfurls, 'Unfurled links')
 

--- a/test/get-links.test.js
+++ b/test/get-links.test.js
@@ -24,4 +24,13 @@ describe('get-links', () => {
     `)
     expect(links).toEqual([])
   })
+
+  test('removes duplicate links', () => {
+    const links = getLinks(`
+      <a href="https://probot.github.io/">https://probot.github.io/</a>
+      <a href="https://probot.github.io/">https://probot.github.io/</a>
+    `)
+
+    expect(links).toEqual(['https://probot.github.io/'])
+  })
 })


### PR DESCRIPTION
Pretty naive way of handling dup links, in that it only works for identical links.

To do: add a test